### PR TITLE
Fix *Error::what to return valid pointer

### DIFF
--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -5,39 +5,48 @@
 
 namespace flom::errors {
 
-class InvalidTimeError : public std::runtime_error {
+class BaseError : public std::exception {
+public:
+  explicit BaseError(const std::string &) noexcept;
+  virtual const char *what() const noexcept;
+
+protected:
+  std::string message;
+};
+
+class InvalidTimeError : public BaseError {
 public:
   explicit InvalidTimeError(double);
   virtual const char *what() const noexcept;
 };
 
-class OutOfFramesError : public std::out_of_range {
+class OutOfFramesError : public BaseError {
 public:
   explicit OutOfFramesError(double);
   virtual const char *what() const noexcept;
 };
 
-class ParseError : public std::runtime_error {
+class ParseError : public BaseError {
 public:
   // TODO: include additional information
   ParseError();
   virtual const char *what() const noexcept;
 };
 
-class SerializationError : public std::runtime_error {
+class SerializationError : public BaseError {
 public:
   // TODO: include additional information
   SerializationError();
   virtual const char *what() const noexcept;
 };
 
-class JSONLoadError : public std::runtime_error {
+class JSONLoadError : public BaseError {
 public:
   explicit JSONLoadError(const std::string &);
   virtual const char *what() const noexcept;
 };
 
-class JSONDumpError : public std::runtime_error {
+class JSONDumpError : public BaseError {
 public:
   explicit JSONDumpError(const std::string &);
   virtual const char *what() const noexcept;

--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -1,7 +1,8 @@
 #ifndef FLOM_ERRORS_HPP
 #define FLOM_ERRORS_HPP
 
-#include <stdexcept>
+#include <exception>
+#include <string>
 
 namespace flom::errors {
 

--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -5,42 +5,62 @@
 
 namespace flom::errors {
 
-class InvalidTimeError : public std::runtime_error {
+class InvalidTimeError : public std::exception {
 public:
   explicit InvalidTimeError(double);
   virtual const char *what() const noexcept;
+
+  double time() const noexcept;
+
+private:
+  double t;
 };
 
-class OutOfFramesError : public std::out_of_range {
+class OutOfFramesError : public std::exception {
 public:
   explicit OutOfFramesError(double);
   virtual const char *what() const noexcept;
+
+  double time() const noexcept;
+
+private:
+  double t;
 };
 
-class ParseError : public std::runtime_error {
+class ParseError : public std::exception {
 public:
   // TODO: include additional information
   ParseError();
   virtual const char *what() const noexcept;
 };
 
-class SerializationError : public std::runtime_error {
+class SerializationError : public std::exception {
 public:
   // TODO: include additional information
   SerializationError();
   virtual const char *what() const noexcept;
 };
 
-class JSONLoadError : public std::runtime_error {
+class JSONLoadError : public std::exception {
 public:
   explicit JSONLoadError(const std::string &);
   virtual const char *what() const noexcept;
+
+  std::string status() const noexcept;
+
+public:
+  std::string status;
 };
 
-class JSONDumpError : public std::runtime_error {
+class JSONDumpError : public std::exception {
 public:
   explicit JSONDumpError(const std::string &);
   virtual const char *what() const noexcept;
+
+  std::string status() const noexcept;
+
+public:
+  std::string status;
 };
 
 } // namespace flom::errors

--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -46,7 +46,7 @@ public:
   explicit JSONLoadError(const std::string &);
   virtual const char *what() const noexcept;
 
-  std::string status() const noexcept;
+  std::string status_message() const noexcept;
 
 public:
   std::string status;
@@ -57,7 +57,7 @@ public:
   explicit JSONDumpError(const std::string &);
   virtual const char *what() const noexcept;
 
-  std::string status() const noexcept;
+  std::string status_message() const noexcept;
 
 public:
   std::string status;

--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -5,48 +5,39 @@
 
 namespace flom::errors {
 
-class BaseError : public std::exception {
-public:
-  explicit BaseError(const std::string &) noexcept;
-  virtual const char *what() const noexcept;
-
-protected:
-  std::string message;
-};
-
-class InvalidTimeError : public BaseError {
+class InvalidTimeError : public std::runtime_error {
 public:
   explicit InvalidTimeError(double);
   virtual const char *what() const noexcept;
 };
 
-class OutOfFramesError : public BaseError {
+class OutOfFramesError : public std::out_of_range {
 public:
   explicit OutOfFramesError(double);
   virtual const char *what() const noexcept;
 };
 
-class ParseError : public BaseError {
+class ParseError : public std::runtime_error {
 public:
   // TODO: include additional information
   ParseError();
   virtual const char *what() const noexcept;
 };
 
-class SerializationError : public BaseError {
+class SerializationError : public std::runtime_error {
 public:
   // TODO: include additional information
   SerializationError();
   virtual const char *what() const noexcept;
 };
 
-class JSONLoadError : public BaseError {
+class JSONLoadError : public std::runtime_error {
 public:
   explicit JSONLoadError(const std::string &);
   virtual const char *what() const noexcept;
 };
 
-class JSONDumpError : public BaseError {
+class JSONDumpError : public std::runtime_error {
 public:
   explicit JSONDumpError(const std::string &);
   virtual const char *what() const noexcept;

--- a/lib/errors.cpp
+++ b/lib/errors.cpp
@@ -25,45 +25,52 @@ namespace flom::errors {
 
 using namespace std::string_literals;
 
-InvalidTimeError::InvalidTimeError(double t)
-    : std::runtime_error("Time '" + std::to_string(t) + "' is invalid") {}
+InvalidTimeError::InvalidTimeError(double time) : t(time) {}
 
 const char *InvalidTimeError::what() const noexcept {
-  return ("InvalidTimeError: "s + std::runtime_error::what()).c_str();
+  return "Invalid time is supplied";
 }
 
-OutOfFramesError::OutOfFramesError(double t)
-    : std::out_of_range("No frame is avaliable at time " + std::to_string(t)) {}
+double InvalidTimeError::time() const noexcept { return this->t; }
+
+OutOfFramesError::OutOfFramesError(double time) : t(time) {}
 
 const char *OutOfFramesError::what() const noexcept {
-  return ("OutOfFramesError: "s + std::out_of_range::what()).c_str();
+  return "No frame is available at supplied time";
 }
 
-ParseError::ParseError() : std::runtime_error("Could not parse input") {}
+double OutOfFramesError::time() const noexcept { return this->t; }
+
+ParseError::ParseError() {}
 
 const char *ParseError::what() const noexcept {
-  return ("ParseError: "s + std::runtime_error::what()).c_str();
+  return "Could not parse input";
 }
 
-SerializationError::SerializationError()
-    : std::runtime_error("Could not serialize data") {}
+SerializationError::SerializationError() {}
 
 const char *SerializationError::what() const noexcept {
-  return ("SerializationError: "s + std::runtime_error::what()).c_str();
+  return "Could not serialize data";
 }
 
-JSONLoadError::JSONLoadError(const std::string &message)
-    : std::runtime_error("Failed to load from JSON string: " + message) {}
+JSONLoadError::JSONLoadError(const std::string &message) : status(message) {}
 
 const char *JSONLoadError::what() const noexcept {
-  return ("JSONLoadError: "s + std::runtime_error::what()).c_str();
+  return "Failed to load from JSON string";
 }
 
-JSONDumpError::JSONDumpError(const std::string &message)
-    : std::runtime_error("Failed to dump to JSON string: " + message) {}
+std::string JSONLoadError::status_message() const noexcept {
+  return this->status;
+}
+
+JSONDumpError::JSONDumpError(const std::string &message) : status(message) {}
 
 const char *JSONDumpError::what() const noexcept {
-  return ("JSONDumpError: "s + std::runtime_error::what()).c_str();
+  return "Failed to dump to JSON string";
+}
+
+std::string JSONDumpError::status_message() const noexcept {
+  return this->status;
 }
 
 } // namespace flom::errors

--- a/lib/errors.cpp
+++ b/lib/errors.cpp
@@ -25,48 +25,45 @@ namespace flom::errors {
 
 using namespace std::string_literals;
 
-BaseError::BaseError(const std::string &message_) noexcept
-    : message(message_) {}
-
-const char *BaseError::what() const noexcept { return this->message.c_str(); }
-
 InvalidTimeError::InvalidTimeError(double t)
-    : BaseError("Time '" + std::to_string(t) + "' is invalid") {}
+    : std::runtime_error("Time '" + std::to_string(t) + "' is invalid") {}
 
 const char *InvalidTimeError::what() const noexcept {
-  return this->message.c_str();
+  return ("InvalidTimeError: "s + std::runtime_error::what()).c_str();
 }
 
 OutOfFramesError::OutOfFramesError(double t)
-    : BaseError("No frame is avaliable at time " + std::to_string(t)) {}
+    : std::out_of_range("No frame is avaliable at time " + std::to_string(t)) {}
 
 const char *OutOfFramesError::what() const noexcept {
-  return this->message.c_str();
+  return ("OutOfFramesError: "s + std::out_of_range::what()).c_str();
 }
 
-ParseError::ParseError() : BaseError("Could not parse input") {}
+ParseError::ParseError() : std::runtime_error("Could not parse input") {}
 
-const char *ParseError::what() const noexcept { return this->message.c_str(); }
+const char *ParseError::what() const noexcept {
+  return ("ParseError: "s + std::runtime_error::what()).c_str();
+}
 
 SerializationError::SerializationError()
-    : BaseError("Could not serialize data") {}
+    : std::runtime_error("Could not serialize data") {}
 
 const char *SerializationError::what() const noexcept {
-  return this->message.c_str();
+  return ("SerializationError: "s + std::runtime_error::what()).c_str();
 }
 
 JSONLoadError::JSONLoadError(const std::string &message)
-    : BaseError("Failed to load from JSON string: " + message) {}
+    : std::runtime_error("Failed to load from JSON string: " + message) {}
 
 const char *JSONLoadError::what() const noexcept {
-  return this->message.c_str();
+  return ("JSONLoadError: "s + std::runtime_error::what()).c_str();
 }
 
 JSONDumpError::JSONDumpError(const std::string &message)
-    : BaseError("Failed to dump to JSON string: " + message) {}
+    : std::runtime_error("Failed to dump to JSON string: " + message) {}
 
 const char *JSONDumpError::what() const noexcept {
-  return this->message.c_str();
+  return ("JSONDumpError: "s + std::runtime_error::what()).c_str();
 }
 
 } // namespace flom::errors

--- a/lib/errors.cpp
+++ b/lib/errors.cpp
@@ -25,45 +25,48 @@ namespace flom::errors {
 
 using namespace std::string_literals;
 
+BaseError::BaseError(const std::string &message_) noexcept
+    : message(message_) {}
+
+const char *BaseError::what() const noexcept { return this->message.c_str(); }
+
 InvalidTimeError::InvalidTimeError(double t)
-    : std::runtime_error("Time '" + std::to_string(t) + "' is invalid") {}
+    : BaseError("Time '" + std::to_string(t) + "' is invalid") {}
 
 const char *InvalidTimeError::what() const noexcept {
-  return ("InvalidTimeError: "s + std::runtime_error::what()).c_str();
+  return this->message.c_str();
 }
 
 OutOfFramesError::OutOfFramesError(double t)
-    : std::out_of_range("No frame is avaliable at time " + std::to_string(t)) {}
+    : BaseError("No frame is avaliable at time " + std::to_string(t)) {}
 
 const char *OutOfFramesError::what() const noexcept {
-  return ("OutOfFramesError: "s + std::out_of_range::what()).c_str();
+  return this->message.c_str();
 }
 
-ParseError::ParseError() : std::runtime_error("Could not parse input") {}
+ParseError::ParseError() : BaseError("Could not parse input") {}
 
-const char *ParseError::what() const noexcept {
-  return ("ParseError: "s + std::runtime_error::what()).c_str();
-}
+const char *ParseError::what() const noexcept { return this->message.c_str(); }
 
 SerializationError::SerializationError()
-    : std::runtime_error("Could not serialize data") {}
+    : BaseError("Could not serialize data") {}
 
 const char *SerializationError::what() const noexcept {
-  return ("SerializationError: "s + std::runtime_error::what()).c_str();
+  return this->message.c_str();
 }
 
 JSONLoadError::JSONLoadError(const std::string &message)
-    : std::runtime_error("Failed to load from JSON string: " + message) {}
+    : BaseError("Failed to load from JSON string: " + message) {}
 
 const char *JSONLoadError::what() const noexcept {
-  return ("JSONLoadError: "s + std::runtime_error::what()).c_str();
+  return this->message.c_str();
 }
 
 JSONDumpError::JSONDumpError(const std::string &message)
-    : std::runtime_error("Failed to dump to JSON string: " + message) {}
+    : BaseError("Failed to dump to JSON string: " + message) {}
 
 const char *JSONDumpError::what() const noexcept {
-  return ("JSONDumpError: "s + std::runtime_error::what()).c_str();
+  return this->message.c_str();
 }
 
 } // namespace flom::errors


### PR DESCRIPTION
- Fix #11 
- All error classes inherit from `std::exception`
- Additional information about error can be obtained from provided methods (`time()`, `status_message()`)
