### PR TITLE
Keep integrity of joint names and effector names

### DIFF
--- a/include/flom/errors.hpp
+++ b/include/flom/errors.hpp
@@ -83,6 +83,17 @@ public:
   std::string status;
 };
 
+class InvalidMotionError : public std::exception {
+public:
+  InvalidMotionError(const std::string &);
+  virtual const char *what() const noexcept;
+
+  std::string status_message() const noexcept;
+
+public:
+  std::string status;
+};
+
 } // namespace flom::errors
 
 #endif

--- a/include/flom/motion.hpp
+++ b/include/flom/motion.hpp
@@ -55,6 +55,10 @@ public:
          const std::unordered_set<std::string> &effector_names,
          const std::string &model = "");
 
+  Motion(const std::unordered_set<std::string> &joint_names,
+         const std::unordered_map<std::string, EffectorType> &effector_types,
+         const std::string &model = "");
+
   Motion(Motion const &);
   ~Motion();
 

--- a/include/flom/motion.hpp
+++ b/include/flom/motion.hpp
@@ -91,6 +91,8 @@ public:
   KeyRange<std::string> effector_names() const;
 
 private:
+  Motion();
+
   class Impl;
   std::unique_ptr<Impl> impl;
 };

--- a/include/flom/motion.hpp
+++ b/include/flom/motion.hpp
@@ -91,8 +91,6 @@ public:
   KeyRange<std::string> effector_names() const;
 
 private:
-  Motion();
-
   class Impl;
   std::unique_ptr<Impl> impl;
 };

--- a/include/flom/motion.hpp
+++ b/include/flom/motion.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace flom {
@@ -50,9 +51,9 @@ public:
   static Motion load_json_string(std::string const &);
   static Motion load_legacy_json(std::ifstream &);
 
-  Motion();
-  // With model name
-  explicit Motion(std::string const &);
+  Motion(const std::unordered_set<std::string> &joint_names,
+         const std::unordered_set<std::string> &effector_names,
+         const std::string &model = "");
 
   Motion(Motion const &);
   ~Motion();

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -27,6 +27,8 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace flom {
 
@@ -35,13 +37,19 @@ public:
   std::string model_id;
   LoopType loop;
   std::map<double, Frame> raw_frames;
+  std::unordered_set<std::string> joint_names;
   std::unordered_map<std::string, EffectorType> effector_types;
 
-  Impl() : model_id(), loop(LoopType::None), raw_frames(), effector_types() {
-    this->add_initial_frame();
-  }
-  Impl(std::string const &model)
-      : model_id(model), loop(LoopType::None), raw_frames(), effector_types() {
+  Impl(const std::unordered_set<std::string> &joints,
+       const std::unordered_set<std::string> &effectors,
+       const std::string &model = "")
+      : model_id(model), loop(LoopType::None), raw_frames(),
+        joint_names(joints), effector_types() {
+    this->effector_types.reserve(effectors.size());
+    for (const auto &name : effectors) {
+      auto const end = std::cend(this->effector_types);
+      this->effector_types.emplace_hint(end, name, EffectorType{});
+    }
     this->add_initial_frame();
   }
 

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -40,6 +40,8 @@ public:
   std::unordered_set<std::string> joint_names;
   std::unordered_map<std::string, EffectorType> effector_types;
 
+  Impl() : loop(LoopType::None) { this->add_initial_frame(); }
+
   Impl(const std::unordered_set<std::string> &joints,
        const std::unordered_map<std::string, EffectorType> &effectors,
        const std::string &model = "")

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -55,7 +55,7 @@ public:
   LoopType loop;
   std::map<double, Frame> raw_frames;
 
-  // These two member must not be changed after construction
+  // keys of these two member must not be changed after construction
   std::unordered_set<std::string> joint_names;
   std::unordered_map<std::string, EffectorType> effector_types;
 

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -64,8 +64,6 @@ public:
   // Hash of keys of effector_types
   std::size_t effectors_hash;
 
-  Impl() : loop(LoopType::None) { this->add_initial_frame(); }
-
   Impl(const std::unordered_set<std::string> &joints,
        const std::unordered_map<std::string, EffectorType> &effectors,
        const std::string &model = "")

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -57,8 +57,7 @@ public:
         joint_names(joints), effector_types() {
     this->effector_types.reserve(effectors.size());
     for (const auto &name : effectors) {
-      auto const end = std::cend(this->effector_types);
-      this->effector_types.emplace_hint(end, name, EffectorType{});
+      this->effector_types.emplace(name, EffectorType{});
     }
     this->add_initial_frame();
   }

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -41,6 +41,14 @@ public:
   std::unordered_map<std::string, EffectorType> effector_types;
 
   Impl(const std::unordered_set<std::string> &joints,
+       const std::unordered_map<std::string, EffectorType> &effectors,
+       const std::string &model = "")
+      : model_id(model), loop(LoopType::None), raw_frames(),
+        joint_names(joints), effector_types(effectors) {
+    this->add_initial_frame();
+  }
+
+  Impl(const std::unordered_set<std::string> &joints,
        const std::unordered_set<std::string> &effectors,
        const std::string &model = "")
       : model_id(model), loop(LoopType::None), raw_frames(),

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -56,13 +56,13 @@ public:
   std::map<double, Frame> raw_frames;
 
   // keys of these two member must not be changed after construction
-  std::unordered_set<std::string> joint_names;
+  const std::unordered_set<std::string> joint_names;
   std::unordered_map<std::string, EffectorType> effector_types;
 
   // Hash of joint_names
-  std::size_t joints_hash;
+  const std::size_t joints_hash;
   // Hash of keys of effector_types
-  std::size_t effectors_hash;
+  const std::size_t effectors_hash;
 
   Impl(const std::unordered_set<std::string> &joints,
        const std::unordered_map<std::string, EffectorType> &effectors,

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -70,6 +70,7 @@ public:
   proto::Motion to_protobuf() const;
 
   bool is_valid() const;
+  bool is_valid_frame(const Frame &) const;
 };
 
 template <typename K> std::size_t names_hash(const std::unordered_set<K> &s) {

--- a/include/flom/motion.impl.hpp
+++ b/include/flom/motion.impl.hpp
@@ -25,7 +25,9 @@
 
 #include "motion.pb.h"
 
+#include <functional>
 #include <map>
+#include <numeric>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -69,6 +71,21 @@ public:
 
   bool is_valid() const;
 };
+
+template <typename K> std::size_t names_hash(const std::unordered_set<K> &s) {
+  auto h{s.hash_function()};
+  return std::accumulate(std::cbegin(s), std::cend(s),
+                         static_cast<std::size_t>(0),
+                         [&h](auto r, const auto &p) { return r ^ h(p); });
+}
+
+template <typename K, typename V>
+std::size_t names_hash(const std::unordered_map<K, V> &m) {
+  auto h{m.hash_function()};
+  return std::accumulate(
+      std::cbegin(m), std::cend(m), static_cast<std::size_t>(0),
+      [&h](auto r, const auto &p) { return r ^ h(p.first); });
+}
 
 } // namespace flom
 

--- a/lib/errors.cpp
+++ b/lib/errors.cpp
@@ -73,4 +73,15 @@ std::string JSONDumpError::status_message() const noexcept {
   return this->status;
 }
 
+InvalidMotionError::InvalidMotionError(const std::string &message)
+    : status(message) {}
+
+const char *InvalidMotionError::what() const noexcept {
+  return "Invalid motion data is detected";
+}
+
+std::string InvalidMotionError::status_message() const noexcept {
+  return this->status;
+}
+
 } // namespace flom::errors

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -30,9 +30,11 @@
 
 namespace flom {
 
-Motion::Motion() : impl(std::make_unique<Motion::Impl>()) {}
-Motion::Motion(std::string const &model)
-    : impl(std::make_unique<Motion::Impl>(model)) {}
+Motion::Motion(const std::unordered_set<std::string> &joint_names,
+               const std::unordered_set<std::string> &effector_names,
+               const std::string &model)
+    : impl(std::make_unique<Motion::Impl>(joint_names, effector_names, model)) {
+}
 Motion::Motion(Motion const &m)
     : impl(std::make_unique<Motion::Impl>(*m.impl)) {}
 Motion::~Motion() {}

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -48,9 +48,6 @@ Motion::Motion(Motion const &m)
 
 Motion::~Motion() {}
 
-// private default constructor
-Motion::Motion() : impl(std::make_unique<Motion::Impl>()) {}
-
 bool Motion::is_valid() const { return this->impl && this->impl->is_valid(); }
 
 Frame Motion::frame_at(double t) const {

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -162,12 +162,9 @@ bool Motion::Impl::is_valid() const {
 }
 
 bool Motion::Impl::is_valid_frame(const Frame &frame) const {
-  // TODO: cache *_hash on construction
-  auto const joints_hash = names_hash(this->joint_names);
-  auto const effectors_hash = names_hash(this->effector_types);
-
   auto const &[p, e] = frame;
-  if (names_hash(p) != joints_hash || names_hash(e) != effectors_hash) {
+  if (names_hash(p) != this->joints_hash ||
+      names_hash(e) != this->effectors_hash) {
     return false;
   }
   return true;

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -43,7 +43,11 @@ Motion::Motion(
 }
 Motion::Motion(Motion const &m)
     : impl(std::make_unique<Motion::Impl>(*m.impl)) {}
+
 Motion::~Motion() {}
+
+// private default constructor
+Motion::Motion() : impl(std::make_unique<Motion::Impl>()) {}
 
 bool Motion::is_valid() const { return this->impl && this->impl->is_valid(); }
 

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -127,7 +127,19 @@ double Motion::length() const {
 void Motion::Impl::add_initial_frame() {
   assert(this->raw_frames.size() == 0 && "raw_frames already initialized");
 
-  this->raw_frames.emplace(0.0, Frame{});
+  Frame frame;
+
+  frame.positions.reserve(this->joint_names.size());
+  for (const auto &name : this->joint_names) {
+    frame.positions.emplace(name, 0.0);
+  }
+
+  frame.effectors.reserve(this->effector_types.size());
+  for (const auto &[name, type] : this->effector_types) {
+    frame.effectors.emplace(name, Effector{});
+  }
+
+  this->raw_frames.emplace(0.0, frame);
 }
 
 bool Motion::Impl::is_valid() const {

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -139,13 +139,21 @@ bool Motion::Impl::is_valid() const {
     return false;
   }
 
-  auto const joints_hash = names_hash(this->joint_names);
-  auto const effectors_hash = names_hash(this->effector_types);
   for (auto const &[t, frame] : this->raw_frames) {
-    auto const &[p, e] = frame;
-    if (names_hash(p) != joints_hash || names_hash(e) != effectors_hash) {
+    if (!this->is_valid_frame(frame)) {
       return false;
     }
+  }
+  return true;
+}
+
+bool Motion::Impl::is_valid_frame(const Frame &frame) const {
+  auto const joints_hash = names_hash(this->joint_names);
+  auto const effectors_hash = names_hash(this->effector_types);
+
+  auto const &[p, e] = frame;
+  if (names_hash(p) != joints_hash || names_hash(e) != effectors_hash) {
+    return false;
   }
   return true;
 }

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -25,6 +25,8 @@
 
 #include "motion.pb.h"
 
+#include <boost/range/adaptors.hpp>
+
 #include <cmath>
 #include <string>
 
@@ -160,11 +162,11 @@ bool Motion::Impl::is_valid_frame(const Frame &frame) const {
 }
 
 KeyRange<std::string> Motion::joint_names() const {
-  return this->impl->raw_frames.begin()->second.joint_names();
+  return this->impl->joint_names;
 }
 
 KeyRange<std::string> Motion::effector_names() const {
-  return this->impl->raw_frames.begin()->second.effector_names();
+  return this->impl->effector_types | boost::adaptors::map_keys;
 }
 
 bool operator==(const Motion &m1, const Motion &m2) {

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -135,8 +135,19 @@ bool Motion::Impl::is_valid() const {
   // which is constructed only using public interface,
   // must not be marked as invalid by this method.
   //
-  // TODO: check whether all frames has same names
-  return this->raw_frames.size() > 0 && this->raw_frames.begin()->first == 0;
+  if (this->raw_frames.size() == 0 || this->raw_frames.begin()->first != 0) {
+    return false;
+  }
+
+  auto const joints_hash = names_hash(this->joint_names);
+  auto const effectors_hash = names_hash(this->effector_types);
+  for (auto const &[t, frame] : this->raw_frames) {
+    auto const &[p, e] = frame;
+    if (names_hash(p) != joints_hash || names_hash(e) != effectors_hash) {
+      return false;
+    }
+  }
+  return true;
 }
 
 KeyRange<std::string> Motion::joint_names() const {

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -148,6 +148,7 @@ bool Motion::Impl::is_valid() const {
 }
 
 bool Motion::Impl::is_valid_frame(const Frame &frame) const {
+  // TODO: cache *_hash on construction
   auto const joints_hash = names_hash(this->joint_names);
   auto const effectors_hash = names_hash(this->effector_types);
 

--- a/lib/motion.cpp
+++ b/lib/motion.cpp
@@ -35,6 +35,12 @@ Motion::Motion(const std::unordered_set<std::string> &joint_names,
                const std::string &model)
     : impl(std::make_unique<Motion::Impl>(joint_names, effector_names, model)) {
 }
+Motion::Motion(
+    const std::unordered_set<std::string> &joint_names,
+    const std::unordered_map<std::string, EffectorType> &effector_types,
+    const std::string &model)
+    : impl(std::make_unique<Motion::Impl>(joint_names, effector_types, model)) {
+}
 Motion::Motion(Motion const &m)
     : impl(std::make_unique<Motion::Impl>(*m.impl)) {}
 Motion::~Motion() {}

--- a/lib/motion_io.cpp
+++ b/lib/motion_io.cpp
@@ -104,6 +104,10 @@ Motion Motion::Impl::from_protobuf(proto::Motion const &motion_proto) {
                    });
   }
 
+  if (!m.is_valid()) {
+    throw errors::InvalidMotionError{"while loading parsed motion data"};
+  }
+
   // copy occurs...
   return m;
 }
@@ -131,6 +135,11 @@ std::string Motion::dump_json_string() const {
 }
 
 proto::Motion Motion::Impl::to_protobuf() const {
+  if (!this->is_valid()) {
+    throw errors::InvalidMotionError{
+        "converting motion data before serializaion"};
+  }
+
   proto::Motion m;
   m.set_model_id(this->model_id);
   if (this->loop == LoopType::Wrap) {

--- a/lib/motion_io.cpp
+++ b/lib/motion_io.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <unordered_set>
 
 #include <google/protobuf/util/json_util.h>
 
@@ -59,27 +60,27 @@ Motion Motion::load_json_string(std::string const &s) {
 }
 
 Motion Motion::Impl::from_protobuf(proto::Motion const &motion_proto) {
-  Motion m;
-  m.impl->model_id = motion_proto.model_id();
+  std::unordered_set<std::string> joint_names;
+  std::unordered_map<std::string, EffectorType> effector_types;
+  std::transform(std::cbegin(motion_proto.effector_types()),
+                 std::cend(motion_proto.effector_types()),
+                 std::inserter(effector_types, std::end(effector_types)),
+                 [](auto const &p) {
+                   auto const &[link, type_proto] = p;
+                   return std::make_pair(
+                       link, proto_util::unpack_effector_type(type_proto));
+                 });
+  auto const &init_pos = motion_proto.frames(0).positions();
+  std::transform(std::cbegin(init_pos), std::cend(init_pos),
+                 std::inserter(joint_names, std::end(joint_names)),
+                 [](auto const &p) { return p.first; });
+
+  Motion m(joint_names, effector_types, motion_proto.model_id());
   if (motion_proto.loop() == proto::Motion::Loop::Motion_Loop_Wrap) {
     m.impl->loop = LoopType::Wrap;
   } else if (motion_proto.loop() == proto::Motion::Loop::Motion_Loop_None) {
     m.impl->loop = LoopType::None;
   }
-  std::transform(
-      std::cbegin(motion_proto.effector_types()),
-      std::cend(motion_proto.effector_types()),
-      std::inserter(m.impl->effector_types, std::end(m.impl->effector_types)),
-      [](auto const &p) {
-        auto const &[link, type_proto] = p;
-        return std::make_pair(link,
-                              proto_util::unpack_effector_type(type_proto));
-      });
-  auto const &init_pos = motion_proto.frames(0).positions();
-  std::transform(
-      std::cbegin(init_pos), std::cend(init_pos),
-      std::inserter(m.impl->joint_names, std::end(m.impl->joint_names)),
-      [](auto const &p) { return p.first; });
   for (auto const &frame_proto : motion_proto.frames()) {
     auto &frame = m.impl->raw_frames[frame_proto.t()];
     auto const &positions_proto = frame_proto.positions();
@@ -180,8 +181,21 @@ Motion Motion::load_legacy_json(std::ifstream &s) {
   json json_data;
   s >> json_data;
 
-  Motion m;
-  m.impl->model_id = json_data["model"];
+  std::unordered_set<std::string> joint_names, effector_names;
+  {
+    auto const &init_frame = json_data["frames"][0];
+    auto const positions = init_frame["position"];
+    // TODO: Use <algorithm> (e.g. std::copy)
+    for (auto it = std::cbegin(positions); it != std::cend(positions); ++it) {
+      joint_names.insert(it.key());
+    }
+    auto const effectors = init_frame["effector"];
+    for (auto it = std::cbegin(effectors); it != std::cend(effectors); ++it) {
+      effector_names.insert(it.key());
+    }
+  }
+
+  Motion m(joint_names, effector_names, json_data["model"]);
   {
     auto loop_type = json_data["loop"];
     if (loop_type == "wrap") {

--- a/lib/motion_io.cpp
+++ b/lib/motion_io.cpp
@@ -215,7 +215,6 @@ Motion Motion::load_legacy_json(std::ifstream &s) {
       // TODO: Use <algorithm> (e.g. std::copy)
       for (auto it = std::cbegin(positions); it != std::cend(positions); ++it) {
         f.positions[it.key()] = it.value();
-        m.impl->joint_names.insert(it.key());
       }
       auto const effectors = frame["effector"];
       for (auto it = std::cbegin(effectors); it != std::cend(effectors); ++it) {

--- a/lib/motion_io.cpp
+++ b/lib/motion_io.cpp
@@ -259,6 +259,11 @@ Motion Motion::load_legacy_json(std::ifstream &s) {
       m.impl->raw_frames[time] = std::move(f);
     }
   }
+
+  if (!m.is_valid()) {
+    throw errors::InvalidMotionError{"while loading legacy motion data"};
+  }
+
   // copy occurs...
   return m;
 }

--- a/lib/motion_io.cpp
+++ b/lib/motion_io.cpp
@@ -75,6 +75,11 @@ Motion Motion::Impl::from_protobuf(proto::Motion const &motion_proto) {
         return std::make_pair(link,
                               proto_util::unpack_effector_type(type_proto));
       });
+  auto const &init_pos = motion_proto.frames(0).positions();
+  std::transform(
+      std::cbegin(init_pos), std::cend(init_pos),
+      std::inserter(m.impl->joint_names, std::end(m.impl->joint_names)),
+      [](auto const &p) { return p.first; });
   for (auto const &frame_proto : motion_proto.frames()) {
     auto &frame = m.impl->raw_frames[frame_proto.t()];
     auto const &positions_proto = frame_proto.positions();
@@ -187,6 +192,7 @@ Motion Motion::load_legacy_json(std::ifstream &s) {
       // TODO: Use <algorithm> (e.g. std::copy)
       for (auto it = std::cbegin(positions); it != std::cend(positions); ++it) {
         f.positions[it.key()] = it.value();
+        m.impl->joint_names.insert(it.key());
       }
       auto const effectors = frame["effector"];
       for (auto it = std::cbegin(effectors); it != std::cend(effectors); ++it) {

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -159,7 +159,11 @@ template <> struct Arbitrary<flom::Motion> {
             using StringSet = std::unordered_set<std::string>;
             auto joint_names_gen = gen::container<StringSet>(num_joints, str_gen);
             auto effector_names_gen = gen::container<StringSet>(num_effectors, str_gen);
-            auto positions_gen = gen::container<std::vector<double>>(num_joints, gen::arbitrary<double>());
+            auto positions_gen = gen::container<std::vector<double>>(num_joints,
+                gen::map(gen::inRange(-half_pi_100, half_pi_100),
+                  [](auto i){ return static_cast<double>(i) / 100; }
+                )
+              );
             auto effectors_gen = gen::container<std::vector<flom::Effector>>(num_effectors, gen::arbitrary<flom::Effector>());
             auto frames_gen = gen::nonEmpty(gen::container<std::vector<std::pair<std::vector<double>, std::vector<flom::Effector>>>>(gen::pair(positions_gen, effectors_gen)));
             return gen::tuple(joint_names_gen, effector_names_gen, frames_gen);

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -150,8 +150,8 @@ template <> struct Arbitrary<flom::Motion> {
         gen::positive<double>(),
         gen::mapcat(
            gen::pair(
-             gen::arbitrary<std::size_t>(),
-             gen::arbitrary<std::size_t>()
+             gen::inRange<std::size_t>(0, 1e3),
+             gen::inRange<std::size_t>(0, 1e3)
           ),
           [](auto const& t) {
             auto const [num_joints, num_effectors] = t;

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -147,7 +147,7 @@ template <> struct Arbitrary<flom::Motion> {
         // UTF8 string is required
         gen::nonEmpty(gen::container<std::string>(gen::inRange('a', 'z'))),
         gen::element(flom::LoopType::None, flom::LoopType::Wrap),
-        gen::nonZero<double>(),
+        gen::positive<double>(),
         gen::mapcat(
            gen::pair(
              gen::arbitrary<std::size_t>(),

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -164,7 +164,11 @@ template <> struct Arbitrary<flom::Motion> {
                   [](auto i){ return static_cast<double>(i) / 100; }
                 )
               );
-            auto effectors_gen = gen::container<std::vector<flom::Effector>>(num_effectors, gen::arbitrary<flom::Effector>());
+            auto effector_gen = gen::build(
+                gen::construct<flom::Effector>(),
+                gen::set(&flom::Effector::location, gen::arbitrary<flom::Location>()),
+                gen::set(&flom::Effector::rotation, gen::arbitrary<flom::Rotation>()));
+            auto effectors_gen = gen::container<std::vector<flom::Effector>>(num_effectors, effector_gen);
             auto frames_gen = gen::nonEmpty(gen::container<std::vector<std::pair<std::vector<double>, std::vector<flom::Effector>>>>(gen::pair(positions_gen, effectors_gen)));
             return gen::tuple(joint_names_gen, effector_names_gen, frames_gen);
         }));

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -24,6 +24,9 @@
 #include <boost/qvm/quat_operations.hpp>
 #include <boost/qvm/vec.hpp>
 
+#include <boost/range/adaptors.hpp>
+#include <boost/range/algorithm.hpp>
+
 #include <rapidcheck.h>
 
 #include <flom/effector.hpp>
@@ -125,7 +128,11 @@ template <> struct Arbitrary<flom::Motion> {
   static auto arbitrary() -> decltype(auto) {
     return gen::apply(
         [](std::string const &model_id, flom::LoopType loop, double fps, auto const& frames) {
-          flom::Motion m(model_id);
+          std::unordered_set<std::string> joint_names, effector_names;
+          auto const& init_frame = frames[0];
+          boost::copy(init_frame.first | boost::adaptors::map_keys, std::inserter(joint_names, std::end(joint_names)));
+          boost::copy(init_frame.second | boost::adaptors::map_keys, std::inserter(effector_names, std::end(effector_names)));
+          flom::Motion m(joint_names, effector_names, model_id);
           m.set_loop(loop);
           unsigned i = 0;
           for (auto const& [p, e] : frames) {

--- a/test/generators.hpp
+++ b/test/generators.hpp
@@ -155,20 +155,24 @@ template <> struct Arbitrary<flom::Motion> {
           ),
           [](auto const& t) {
             auto const [num_joints, num_effectors] = t;
-            auto str_gen = gen::container<std::string>(gen::inRange('a', 'z'));
+
             using StringSet = std::unordered_set<std::string>;
+            auto str_gen = gen::container<std::string>(gen::inRange('a', 'z'));
             auto joint_names_gen = gen::container<StringSet>(num_joints, str_gen);
             auto effector_names_gen = gen::container<StringSet>(num_effectors, str_gen);
-            auto positions_gen = gen::container<std::vector<double>>(num_joints,
-                gen::map(gen::inRange(-half_pi_100, half_pi_100),
-                  [](auto i){ return static_cast<double>(i) / 100; }
-                )
+
+            auto position_gen = gen::map(gen::inRange(-half_pi_100, half_pi_100),
+                [](auto i){ return static_cast<double>(i) / 100; }
               );
+            auto positions_gen = gen::container<std::vector<double>>(num_joints, position_gen);
+
             auto effector_gen = gen::build(
                 gen::construct<flom::Effector>(),
                 gen::set(&flom::Effector::location, gen::arbitrary<flom::Location>()),
-                gen::set(&flom::Effector::rotation, gen::arbitrary<flom::Rotation>()));
+                gen::set(&flom::Effector::rotation, gen::arbitrary<flom::Rotation>())
+              );
             auto effectors_gen = gen::container<std::vector<flom::Effector>>(num_effectors, effector_gen);
+
             auto frames_gen = gen::nonEmpty(gen::container<std::vector<std::pair<std::vector<double>, std::vector<flom::Effector>>>>(gen::pair(positions_gen, effectors_gen)));
             return gen::tuple(joint_names_gen, effector_names_gen, frames_gen);
         }));

--- a/test/motion.cpp
+++ b/test/motion.cpp
@@ -41,12 +41,16 @@
 BOOST_AUTO_TEST_SUITE(motion)
 
 BOOST_AUTO_TEST_CASE(empty_motion_valid) {
-  auto const empty = flom::Motion();
+  std::unordered_set<std::string> j, e;
+  auto const empty = flom::Motion(j, e);
   BOOST_TEST(empty.is_valid());
 }
 
-RC_BOOST_PROP(empty_named_motion_valid, (const std::string &name)) {
-  auto const empty = flom::Motion(name);
+RC_BOOST_PROP(empty_named_motion_valid,
+              (const std::string &name,
+               const std::unordered_set<std::string> &j,
+               const std::unordered_set<std::string> &e)) {
+  auto const empty = flom::Motion(j, e, name);
   RC_ASSERT(empty.is_valid());
 }
 

--- a/test/motion.cpp
+++ b/test/motion.cpp
@@ -189,6 +189,8 @@ RC_BOOST_PROP(effector_list, (const flom::Motion &m, double t)) {
 }
 
 RC_BOOST_PROP(dump_load, (const flom::Motion &m)) {
+  RC_PRE(m.is_valid());
+
   auto const path = std::filesystem::temp_directory_path() / "out.fom";
 
   {
@@ -210,6 +212,8 @@ RC_BOOST_PROP(dump_load, (const flom::Motion &m)) {
 }
 
 RC_BOOST_PROP(dump_load_json, (const flom::Motion &m)) {
+  RC_PRE(m.is_valid());
+
   auto const path = std::filesystem::temp_directory_path() / "out.json";
 
   {

--- a/test/motion.cpp
+++ b/test/motion.cpp
@@ -57,7 +57,7 @@ RC_BOOST_PROP(empty_named_motion_valid,
 RC_BOOST_PROP(retrieve_frame_wrap, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.loop() == flom::LoopType::Wrap);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   auto frame = m.frame_at(t);
 
@@ -78,7 +78,7 @@ RC_BOOST_PROP(retrieve_frame_none, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.length() >= t);
   RC_PRE(m.loop() == flom::LoopType::None);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   auto frame = m.frame_at(t);
 
@@ -96,7 +96,7 @@ RC_BOOST_PROP(retrieve_frame_none, (const flom::Motion &m, double t)) {
 }
 
 RC_BOOST_PROP(retrieve_frame_none_throw, (const flom::Motion &m)) {
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
   RC_PRE(m.loop() == flom::LoopType::None);
 
   // Using unsigned long because RapidCheck doesn't support gen::inRange<double>
@@ -109,7 +109,7 @@ RC_BOOST_PROP(retrieve_frame_none_throw, (const flom::Motion &m)) {
 }
 
 RC_BOOST_PROP(invalid_time, (const flom::Motion &m)) {
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   const double nan = std::numeric_limits<double>::quiet_NaN();
   RC_ASSERT_THROWS_AS(m.frame_at(-1), flom::errors::InvalidTimeError);
@@ -120,7 +120,7 @@ RC_BOOST_PROP(frames_range_none, (const flom::Motion &m, double fps)) {
   RC_PRE(fps > 0);
   RC_PRE(m.length() >= fps);
   RC_PRE(m.loop() == flom::LoopType::None);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   unsigned long count = 0;
   for (auto const &frame : m.frames(fps)) {
@@ -136,7 +136,7 @@ RC_BOOST_PROP(frames_range_none, (const flom::Motion &m, double fps)) {
 RC_BOOST_PROP(frames_range_wrap, (const flom::Motion &m, double fps)) {
   RC_PRE(fps > 0);
   RC_PRE(m.loop() == flom::LoopType::Wrap);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   unsigned long count = 0;
   for (auto const &frame : m.frames(fps)) {
@@ -151,7 +151,7 @@ RC_BOOST_PROP(frames_range_wrap, (const flom::Motion &m, double fps)) {
 RC_BOOST_PROP(in_range_t_none, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.loop() == flom::LoopType::None);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   RC_ASSERT((m.length() >= t) == m.is_in_range_at(t));
 }
@@ -159,7 +159,7 @@ RC_BOOST_PROP(in_range_t_none, (const flom::Motion &m, double t)) {
 RC_BOOST_PROP(in_range_t_wrap, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.loop() == flom::LoopType::Wrap);
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   RC_ASSERT(m.is_in_range_at(t));
 }
@@ -167,7 +167,7 @@ RC_BOOST_PROP(in_range_t_wrap, (const flom::Motion &m, double t)) {
 RC_BOOST_PROP(joint_list, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.is_in_range_at(t));
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   std::unordered_set<std::string> o1, o2;
   boost::copy(m.frame_at(t).joint_names(), std::inserter(o1, std::end(o1)));
@@ -179,7 +179,7 @@ RC_BOOST_PROP(joint_list, (const flom::Motion &m, double t)) {
 RC_BOOST_PROP(effector_list, (const flom::Motion &m, double t)) {
   RC_PRE(t >= 0);
   RC_PRE(m.is_in_range_at(t));
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   std::unordered_set<std::string> o1, o2;
   boost::copy(m.frame_at(t).effector_names(), std::inserter(o1, std::end(o1)));
@@ -189,7 +189,7 @@ RC_BOOST_PROP(effector_list, (const flom::Motion &m, double t)) {
 }
 
 RC_BOOST_PROP(dump_load, (const flom::Motion &m)) {
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   auto const path = std::filesystem::temp_directory_path() / "out.fom";
 
@@ -212,7 +212,7 @@ RC_BOOST_PROP(dump_load, (const flom::Motion &m)) {
 }
 
 RC_BOOST_PROP(dump_load_json, (const flom::Motion &m)) {
-  RC_PRE(m.is_valid());
+  RC_ASSERT(m.is_valid());
 
   auto const path = std::filesystem::temp_directory_path() / "out.json";
 


### PR DESCRIPTION
- Fix #25
- `is_valid` check whether all frames' integrity are kept
- Currently, `get_or_insert_frame` can potentially break integrity
  - will be fixed in #24